### PR TITLE
Adds initial support for Linksys EA8300

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -31,6 +31,9 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+linksys,ea8300)
+        ubootenv_add_uci_config "/dev/mtd10" "0x0" "0x20000" "0x20000"
+        ;;
 openmesh,a42 |\
 openmesh,a62)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x10000" "0x10000"

--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -15,8 +15,10 @@ KERNELNAME:=zImage Image dtbs
 include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-leds-gpio kmod-gpio-button-hotplug swconfig \
-	kmod-ath10k wpad-mini \
+	kmod-usb-phy-dwc3-ipq40xx kmod-ath10k wpad-mini \
 	kmod-usb3 kmod-usb-dwc3-of-simple kmod-usb-phy-qcom-dwc3 \
-	ath10k-firmware-qca4019
+	kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform \
+	kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
+	ath10k-firmware-qca4019 uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -38,6 +38,11 @@ glinet,gl-b1300)
 	ucidef_add_switch "switch0" \
 		"0u@eth0" "3:lan" "4:lan"
 	;;
+linksys,ea8300)
+        hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+        ucidef_add_switch "switch0" \
+                "1:lan" "2:lan" "3:lan" "4:lan" "0@eth1" "5:wan" "0@eth0"
+        ;;
 openmesh,a42 |\
 openmesh,a62)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -112,9 +112,19 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
+        linksys,ea8300)
+                ath10kcal_extract "0:ART" 4096 12064
+                ;;
 	openmesh,a62)
 		ath10kcal_extract "0:ART" 36864 12064
 		;;
+        esac
+        ;;
+"ath10k/pre-cal-pci-0001:01:00.0.bin")
+        case $board in
+        linksys,ea8300)
+                ath10kcal_extract "0:ART" 20480 12064
+                ;;
 	esac
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -1,0 +1,20 @@
+#!/bin/ash
+
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	linksys,ea8300)
+		echo $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
+		;;
+	*)
+		;;
+esac

--- a/target/linux/ipq40xx/base-files/etc/init.d/linksys_recovery
+++ b/target/linux/ipq40xx/base-files/etc/init.d/linksys_recovery
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2015 OpenWrt.org
+
+START=97
+boot() {
+. /lib/functions.sh
+
+case $(board_name) in
+	linksys,ea8300)
+		# make sure auto_recovery in uboot is always on
+		AUTO_RECOVERY_ENA="`fw_printenv -n auto_recovery`"
+		if [ "$AUTO_RECOVERY_ENA" != "yes" ] ; then
+			fw_setenv auto_recovery yes
+		fi
+		# reset the boot counter
+		mtd resetbc s_env
+		;;
+esac
+}

--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2014-2015 OpenWrt.org
+#
+
+linksys_get_target_firmware() {
+	cur_boot_part=`/usr/sbin/fw_printenv -n boot_part`
+	target_firmware=""
+	if [ "$cur_boot_part" = "1" ]
+	then
+		# current primary boot - update alt boot
+		target_firmware="kernel2"
+		fw_setenv boot_part 2
+		#In EA8300 bootcmd is always "bootipq", so don't change
+		#fw_setenv bootcmd "run altnandboot"
+	elif [ "$cur_boot_part" = "2" ]
+	then
+		# current alt boot - update primary boot
+		target_firmware="kernel1"
+		fw_setenv boot_part 1
+		#In EA8300 bootcmd is always "bootipq", so don't change
+		#fw_setenv bootcmd "run nandboot"
+	fi
+
+	# re-enable recovery so we get back if the new firmware is broken
+	fw_setenv auto_recovery yes
+
+	echo "$target_firmware"
+}
+
+linksys_get_root_magic() {
+	(get_image "$@" | dd skip=786432 bs=4 count=1 | hexdump -v -n 4 -e '1/1 "%02x"') 2>/dev/null
+}
+
+platform_do_upgrade_linksys() {
+	local magic_long="$(get_magic_long "$1")"
+
+	mkdir -p /var/lock
+	local part_label="$(linksys_get_target_firmware)"
+	touch /var/lock/fw_printenv.lock
+
+	if [ ! -n "$part_label" ]
+	then
+		echo "cannot find target partition"
+		exit 1
+	fi
+
+	local target_mtd=$(find_mtd_part $part_label)
+
+	[ "$magic_long" = "73797375" ] && {
+		CI_KERNPART="$part_label"
+		if [ "$part_label" = "kernel1" ]
+		then
+			CI_UBIPART="rootfs1"
+		else
+			CI_UBIPART="rootfs2"
+		fi
+
+
+		# remove "squashfs" vol (in case we are flashing over a stock image, which is also UBI)
+
+		local mtdnum="$( find_mtd_index "$CI_UBIPART" )"
+		if [ ! "$mtdnum" ]; then
+			echo "cannot find ubi mtd partition $CI_UBIPART"
+			return 1
+		fi
+
+		local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+		if [ ! "$ubidev" ]; then
+			ubiattach -m "$mtdnum"
+			sync
+			ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+		fi
+
+		if [ "$ubidev" ]; then
+
+			local squash_ubivol="$( nand_find_volume $ubidev squashfs )"
+
+			# kill volume
+			[ "$squash_ubivol" ] && ubirmvol /dev/$ubidev -N squashfs || true
+		fi
+
+
+		# complete std upgrade
+		nand_upgrade_tar "$1"
+	}
+	[ "$magic_long" = "27051956" ] && {
+		# check firmwares' rootfs types
+		local oldroot="$(linksys_get_root_magic $target_mtd)"
+		local newroot="$(linksys_get_root_magic "$1")"
+
+		if [ "$newroot" = "55424923" -a "$oldroot" = "55424923" ]
+		# we're upgrading from a firmware with UBI to one with UBI
+		then
+			# erase everything to be safe
+			mtd erase $part_label
+			get_image "$1" | mtd -n write - $part_label
+		else
+			get_image "$1" | mtd write - $part_label
+		fi
+	}
+}

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -54,6 +54,9 @@ platform_do_upgrade() {
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
+	linksys,ea8300)
+		platform_do_upgrade_linksys "$ARGV"
+		;;
 	openmesh,a42 |\
 	openmesh,a62)
 		PART_NAME="inactive"

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// DTS for Linksys EA8300 2018-07-15 25:53 by Oliver Welter <contact@verbotene.zone>
+
+#include "qcom-ipq4019-ea8300.dtsi"
+
+/ {
+	model = "Linksys EA8300 Qualcomm IPQ4019 AP DK07.1-c1";
+	compatible = "linksys,ea8300", "qcom,ipq4019-ap-dk07.1-c1";
+
+        memory {
+                device_type = "memory";
+                reg = <0x80000000 0x10000000>; /* 256MB */
+        };
+
+        reserved-memory {
+                #address-cells = <1>;
+                #size-cells = <1>;
+                ranges;
+                rsvd1@87000000 {
+                        /* Reserved for other subsystem */
+                        reg = <0x87000000 0x500000>;
+                        no-map;
+                };
+                wifi_dump@87500000 {
+                        reg = <0x87500000 0x600000>;
+                        no-map;
+                };
+
+                rsvd2@87B00000 {
+                        /* Reserved for other subsystem */
+                        reg = <0x87B00000 0x500000>;
+                        no-map;
+                };
+        };
+
+        chosen {
+                stdout-path = "serial0:115200n8";
+                bootargs-append = " clk_ignore_unused";
+        };
+};

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dtsi
@@ -1,0 +1,1027 @@
+/*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+// Adapted for Linksys EA3800 2018-07-15 by Oliver Welter <contact@verbotene.zone>
+
+/dts-v1/;
+
+#include "qcom-ipq4019.dtsi"
+#include "qcom-ipq4019-bus.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Qualcomm Technologies, Inc. IPQ4019";
+	compatible = "qcom,ipq4019";
+	interrupt-parent = <&intc>;
+
+	aliases {
+		spi0 = &blsp1_spi1;
+		spi1 = &blsp1_spi2;
+		i2c0 = &blsp1_i2c3;
+		i2c1 = &blsp1_i2c4;
+                serial0 = &blsp1_uart1;
+                serial1 = &blsp1_uart2;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			enable-method = "qcom,kpss-acc-v1";
+			qcom,acc = <&acc0>;
+			qcom,saw = <&saw0>;
+			reg = <0x0>;
+			clocks = <&gcc GCC_APPS_CLK_SRC>;
+			clock-frequency = <0>;
+			operating-points = <
+				/* kHz	uV (fixed) */
+				48000	1100000
+				200000	1100000
+				500000	1100000
+				716000  1100000
+			>;
+			clock-latency = <256000>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			enable-method = "qcom,kpss-acc-v1";
+			qcom,acc = <&acc1>;
+			qcom,saw = <&saw1>;
+			reg = <0x1>;
+			clocks = <&gcc GCC_APPS_CLK_SRC>;
+			clock-frequency = <0>;
+		};
+
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			enable-method = "qcom,kpss-acc-v1";
+			qcom,acc = <&acc2>;
+			qcom,saw = <&saw2>;
+			reg = <0x2>;
+			clocks = <&gcc GCC_APPS_CLK_SRC>;
+			clock-frequency = <0>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			enable-method = "qcom,kpss-acc-v1";
+			qcom,acc = <&acc3>;
+			qcom,saw = <&saw3>;
+			reg = <0x3>;
+			clocks = <&gcc GCC_APPS_CLK_SRC>;
+			clock-frequency = <0>;
+		};
+	};
+
+	pmu {
+		compatible = "arm,cortex-a7-pmu";
+		interrupts = <GIC_PPI 7 (GIC_CPU_MASK_SIMPLE(4) |
+					 IRQ_TYPE_LEVEL_HIGH)>;
+	};
+
+	clocks {
+		sleep_clk: sleep_clk {
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+			#clock-cells = <0>;
+		};
+
+		xo: xo {
+			compatible = "fixed-clock";
+			clock-frequency = <48000000>;
+			#clock-cells = <0>;
+		};
+	};
+
+	firmware {
+		scm {
+			compatible = "qcom,scm-ipq4019";
+		};
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupts = <1 2 0xf08>,
+			     <1 3 0xf08>,
+			     <1 4 0xf08>,
+			     <1 1 0xf08>;
+		clock-frequency = <48000000>;
+	};
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		compatible = "simple-bus";
+
+		intc: interrupt-controller@b000000 {
+			compatible = "qcom,msm-qgic2";
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			reg = <0x0b000000 0x1000>,
+			<0x0b002000 0x1000>;
+		};
+
+		gcc: clock-controller@1800000 {
+			compatible = "qcom,gcc-ipq4019";
+			#clock-cells = <1>;
+			#reset-cells = <1>;
+			reg = <0x1800000 0x60000>;
+		};
+
+		adcc: clock-controller@7700038 {
+		        compatible = "qcom,adcc-ipq40xx";
+		        #clock-cells = <1>;
+		        #reset-cells = <1>;
+		        reg = <0x7700038 0x1DC>;
+		        status = "disabled";
+		};
+
+		tcsr: tcsr@194b000 {
+		        compatible = "qcom,tcsr";
+		        reg = <0x194b000 0x100>;
+		        qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		        status = "ok";
+		};
+
+		ess_tcsr: ess_tcsr@1953000 {
+		        compatible = "qcom,tcsr";
+		        reg = <0x1953000 0x1000>;
+		        qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		rng@22000 {
+			compatible = "qcom,prng";
+			reg = <0x22000 0x140>;
+			clocks = <&gcc GCC_PRNG_AHB_CLK>;
+			clock-names = "core";
+			status = "disabled";
+		};
+
+		tlmm: pinctrl@1000000 {
+			compatible = "qcom,ipq4019-pinctrl";
+			reg = <0x01000000 0x300000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <GIC_SPI 208 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		uart1:uart@78b0000 {
+	                compatible = "qcom,msm-hsuart-v14";
+	                reg = <0x78b0000 0x200>,
+	                        <0x7884000 0x23000>;
+	                reg-names = "core_mem", "bam_mem";
+	                interrupt-names = "core_irq", "bam_irq";
+	                #address-cells = <0>;
+        	        interrupt-parent = <&uart1>;
+	                interrupts = <0 1 2>;
+	                #interrupt-cells = <1>;
+	                interrupt-map-mask = <0xffffffff>;
+	                interrupt-map = <0 &intc 0 108 0
+	                        1 &intc 0 238 0>;
+	                qcom,bam-tx-ep-pipe-index = <2>;
+	                qcom,bam-rx-ep-pipe-index = <3>;
+	                qcom,master-id = <86>;
+	                clocks = <&gcc GCC_BLSP1_AHB_CLK>,
+	                        <&gcc GCC_BLSP1_UART2_APPS_CLK>;
+	                clock-names = "iface_clk", "core_clk";
+                        pinctrl-0 = <&uart1_pins>;
+                        pinctrl-1 = <&uart1_pins>;
+                        pinctrl-names = "default", "sleep";
+	                status = "disabled";
+                };
+
+		blsp_dma: dma@7884000 {
+			compatible = "qcom,bam-v1.7.0";
+			reg = <0x07884000 0x23000>;
+			interrupts = <GIC_SPI 238 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_BLSP1_AHB_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+			status = "disabled";
+		};
+
+		blsp1_spi1: spi@78b5000 { /* BLSP1 QUP1 */
+			compatible = "qcom,spi-qup-v2.2.1";
+			reg = <0x78b5000 0x600>;
+			interrupts = <GIC_SPI 95 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_BLSP1_QUP1_SPI_APPS_CLK>,
+				 <&gcc GCC_BLSP1_AHB_CLK>;
+			clock-names = "core", "iface";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&blsp_dma 5>, <&blsp_dma 4>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		blsp1_spi2: spi@78b6000 { /* BLSP1 QUP2 */
+			compatible = "qcom,spi-qup-v2.2.1";
+			reg = <0x78b6000 0x600>;
+			interrupts = <GIC_SPI 96 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_BLSP1_QUP2_SPI_APPS_CLK>,
+				<&gcc GCC_BLSP1_AHB_CLK>;
+			clock-names = "core", "iface";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&blsp_dma 7>, <&blsp_dma 6>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		blsp1_i2c3: i2c@78b7000 { /* BLSP1 QUP3 */
+			compatible = "qcom,i2c-qup-v2.2.1";
+			reg = <0x78b7000 0x600>;
+			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_BLSP1_AHB_CLK>,
+				 <&gcc GCC_BLSP1_QUP1_I2C_APPS_CLK>;
+			clock-names = "iface", "core";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&blsp_dma 9>, <&blsp_dma 8>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		blsp1_i2c4: i2c@78b8000 { /* BLSP1 QUP4 */
+			compatible = "qcom,i2c-qup-v2.2.1";
+			reg = <0x78b8000 0x600>;
+			interrupts = <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_BLSP1_AHB_CLK>,
+				 <&gcc GCC_BLSP1_QUP2_I2C_APPS_CLK>;
+			clock-names = "iface", "core";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&blsp_dma 11>, <&blsp_dma 10>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		cryptobam: dma@8e04000 {
+			compatible = "qcom,bam-v1.7.0";
+			reg = <0x08e04000 0x20000>;
+			interrupts = <GIC_SPI 207 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_CRYPTO_AHB_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <1>;
+			qcom,controlled-remotely;
+			status = "disabled";
+		};
+
+		crypto@8e3a000 {
+			compatible = "qcom,crypto-v5.1";
+			reg = <0x08e3a000 0x6000>;
+			clocks = <&gcc GCC_CRYPTO_AHB_CLK>,
+				 <&gcc GCC_CRYPTO_AXI_CLK>,
+				 <&gcc GCC_CRYPTO_CLK>;
+			clock-names = "iface", "bus", "core";
+			dmas = <&cryptobam 2>, <&cryptobam 3>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+                acc0: clock-controller@b088000 {
+                        compatible = "qcom,kpss-acc-v1";
+                        reg = <0x0b088000 0x1000>, <0xb008000 0x1000>;
+                };
+
+                acc1: clock-controller@b098000 {
+                        compatible = "qcom,kpss-acc-v1";
+                        reg = <0x0b098000 0x1000>, <0xb008000 0x1000>;
+                };
+
+                acc2: clock-controller@b0a8000 {
+                        compatible = "qcom,kpss-acc-v1";
+                        reg = <0x0b0a8000 0x1000>, <0xb008000 0x1000>;
+                };
+
+                acc3: clock-controller@b0b8000 {
+                        compatible = "qcom,kpss-acc-v1";
+                        reg = <0x0b0b8000 0x1000>, <0xb008000 0x1000>;
+                };
+
+                saw0: regulator@b089000 {
+                        compatible = "qcom,saw2";
+                        reg = <0x02089000 0x1000>, <0x0b009000 0x1000>;
+                        regulator;
+                };
+
+                saw1: regulator@b099000 {
+                        compatible = "qcom,saw2";
+                        reg = <0x0b099000 0x1000>, <0x0b009000 0x1000>;
+                        regulator;
+                };
+
+                saw2: regulator@b0a9000 {
+                        compatible = "qcom,saw2";
+                        reg = <0x0b0a9000 0x1000>, <0x0b009000 0x1000>;
+                        regulator;
+                };
+
+                saw3: regulator@b0b9000 {
+                        compatible = "qcom,saw2";
+                        reg = <0x0b0b9000 0x1000>, <0x0b009000 0x1000>;
+                        regulator;
+                };
+
+		blsp1_uart1: serial@78af000 {
+			compatible = "qcom,msm-uartdm-v1.4", "qcom,msm-uartdm";
+			reg = <0x78af000 0x200>;
+			interrupts = <GIC_SPI 107 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+			clocks = <&gcc GCC_BLSP1_UART1_APPS_CLK>,
+				<&gcc GCC_BLSP1_AHB_CLK>;
+			clock-names = "core", "iface";
+			dmas = <&blsp_dma 1>, <&blsp_dma 0>;
+			dma-names = "rx", "tx";
+		};
+
+		blsp1_uart2: serial@78b0000 {
+			compatible = "qcom,msm-uartdm-v1.4", "qcom,msm-uartdm";
+			reg = <0x78b0000 0x200>;
+			interrupts = <GIC_SPI 108 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+			clocks = <&gcc GCC_BLSP1_UART2_APPS_CLK>,
+				<&gcc GCC_BLSP1_AHB_CLK>;
+			clock-names = "core", "iface";
+			dmas = <&blsp_dma 3>, <&blsp_dma 2>;
+			dma-names = "rx", "tx";
+		};
+
+		watchdog@b017000 {
+			compatible = "qcom,kpss-wdt", "qcom,kpss-wdt-ipq4019";
+			reg = <0xb017000 0x40>;
+			clocks = <&sleep_clk>;
+			timeout-sec = <10>;
+			status = "disabled";
+		};
+
+		restart@4ab000 {
+			compatible = "qcom,pshold";
+			reg = <0x4ab000 0x4>;
+		};
+
+		qcom,nand@7980000 {
+		        compatible = "qcom,msm-nand";
+		        reg = <0x07980000 0x40000>,
+		                <0x07984000 0x1A000>;
+		        reg-names = "nand_phys",
+		                        "bam_phys";
+		        interrupts = <0 101 0>;
+		        interrupt-names = "bam_irq";
+		
+		        qcom,msm-bus,name = "qpic_nand";
+		        qcom,msm-bus,num-cases = <2>;
+		        qcom,msm-bus,num-paths = <1>;
+
+		        qcom,msm-bus,vectors-KBps =
+		                <91 512 0 0>,
+		                /* Voting for max b/w on PNOC bus for now */
+		                <91 512 400000 800000>;
+		        clock-names = "iface_clk", "core_clk";
+		        clocks = <&gcc GCC_QPIC_AHB_CLK>,
+		                <&gcc GCC_QPIC_CLK>;
+		        status = "disabled";
+		};
+
+		qpic_bam: dma@7984000 {
+			compatible = "qcom,bam-v1.7.0";
+			reg = <0x7984000 0x1a000>;
+			interrupts = <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&gcc GCC_QPIC_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+			status = "disabled";
+		};
+
+		nand: qpic-nand@79b0000 {
+			compatible = "qcom,ipq4019-nand";
+			reg = <0x79b0000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&gcc GCC_QPIC_CLK>,
+				 <&gcc GCC_QPIC_AHB_CLK>;
+			clock-names = "core", "aon";
+
+			dmas = <&qpic_bam 0>,
+			       <&qpic_bam 1>,
+			       <&qpic_bam 2>;
+			dma-names = "tx", "rx", "cmd";
+			status = "disabled";
+
+			nand@0 {
+				reg = <0>;
+
+				nand-ecc-strength = <4>;
+				nand-ecc-step-size = <512>;
+				nand-bus-width = <8>;
+			};
+		};
+
+		edma@c080000 {
+		        compatible = "qcom,ess-edma";
+		        reg = <0xc080000 0x8000>;
+		        qcom,page-mode = <0>;
+		        qcom,rx_head_buf_size = <1540>;
+		        qcom,wan_port_id_mask = <0x10>;
+		        qcom,mdio_supported;
+		        qcom,phy_mdio_addr = <4>;
+		        qcom,poll_required = <1>;
+		        qcom,forced_speed = <1000>;
+		        qcom,forced_duplex = <1>;
+		
+		        interrupts = <0 65 1>,
+		                        <0 66 1>,
+		                        <0 67 1>,
+		                        <0 68 1>,
+		                        <0 69 1>,
+		                        <0 70 1>,
+		                        <0 71 1>,
+		                        <0 72 1>,
+		                        <0 73 1>,
+		                        <0 74 1>,
+		                        <0 75 1>,
+		                        <0 76 1>,
+		                        <0 77 1>,
+		                        <0 78 1>,
+		                        <0 79 1>,
+		                        <0 80 1>,
+		                        <0 240 1>,
+		                        <0 241 1>,
+		                        <0 242 1>,
+		                        <0 243 1>,
+		                        <0 244 1>,
+		                        <0 245 1>,
+		                        <0 246 1>,
+		                        <0 247 1>,
+		                        <0 248 1>,
+		                        <0 249 1>,
+		                        <0 250 1>,
+		                        <0 251 1>,
+		                        <0 252 1>,
+		                        <0 253 1>,
+		                        <0 254 1>,
+		                        <0 255 1>;
+		        gmac0 {
+		                local-mac-address = [000000000000];
+				qcom,phy_mdio_addr = <4>;
+				qcom,poll_required = <1>;
+				qcom,forced_speed = <1000>;
+				qcom,forced_duplex = <1>;
+				vlan_tag = <2 0x20>;
+		        };
+
+			gmac1: gmac1 {
+				local-mac-address = [00 00 00 00 00 00];
+				qcom,poll_required_dynamic = <1>;
+				vlan_tag = <1 0x1e>;
+			};
+		};
+
+		ess-switch@c000000 {
+		        compatible = "qcom,ess-switch";
+		        reg = <0xc000000 0x80000>; /* 512KB */
+		        switch_access_mode = "local bus";
+		        resets = <&gcc ESS_RESET>, <&gcc ESS_MAC1_CLK_DIS>, \
+		                <&gcc ESS_MAC2_CLK_DIS>, <&gcc ESS_MAC3_CLK_DIS>, \
+		                <&gcc ESS_MAC4_CLK_DIS>, <&gcc ESS_MAC5_CLK_DIS>;
+		        reset-names = "ess_rst","ess_mac1_clk_dis", \
+		                "ess_mac2_clk_dis","ess_mac3_clk_dis", \
+		                "ess_mac4_clk_dis", "ess_mac5_clk_dis";
+		        clocks = <&gcc GCC_ESS_CLK>;
+		        clock-names = "ess_clk";
+		        switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+		        switch_lan_bmp = <0x1e>; /* lan port bitmap */
+		        switch_wan_bmp = <0x20>; /* wan port bitmap */
+                        switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
+                        switch_initvlas = <
+                                0x0007c 0x54 /* PORT0_STATUS */
+                        >;
+                        led_source@0 {
+                                source = <0x1>;  /*source id 1 */
+                                mode = "normal"; /*on,off,blink,normal */
+                                speed = "all";   /*10M,100M,1000M,all */
+                                freq = "auto";   /*2Hz,4Hz,8Hz,auto*/
+                        };
+                        led_source@1 {
+                                source = <0x4>;  /*source id 4 */
+                                mode = "normal"; /*on,off,blink,normal */
+                                speed = "all";   /*10M,100M,1000M,all */
+                                freq = "auto";   /*2Hz,4Hz,8Hz,auto*/
+                        };
+                        led_source@2 {
+                                source = <0x7>;  /*source id 7 */
+                                mode = "normal"; /*on,off,blink,normal */
+                                speed = "all";   /*10M,100M,1000M,all */
+                                freq = "auto";   /*2Hz,4Hz,8Hz,auto*/
+                        };
+                        led_source@3 {
+                                source = <0xa>;  /*source id 10 */
+                                mode = "normal"; /*on,off,blink,normal */
+                                speed = "all";   /*10M,100M,1000M,all */
+                                freq = "auto";   /*2Hz,4Hz,8Hz,auto*/
+                        };
+                        led_source@4 {
+                                source = <0xd>;  /*source id 13 */
+                                mode = "normal"; /*on,off,blink,normal */
+                                speed = "all";   /*10M,100M,1000M,all */
+                                freq = "auto";   /*2Hz,4Hz,8Hz,auto*/
+                        };
+		};
+
+		ess-psgmii@98000 {
+		        compatible = "qcom,ess-psgmii";
+		        reg = <0x98000 0x800>; /* 2k */
+		        psgmii_access_mode = "local bus";
+		        resets = <&gcc ESS_PSGMII_ARES>;
+		        reset-names = "psgmii_rst";
+			status = "disabled";
+		};
+
+		mdio@90000 {
+		        #address-cells = <1>;
+		        #size-cells = <1>;
+		        compatible = "qcom,ipq40xx-mdio";
+		        reg = <0x90000 0x64>;
+			
+		        phy0: ethernet-phy@0 {
+		                reg = <0>;
+		        };
+		        phy1: ethernet-phy@1 {
+		                reg = <1>;
+		        };
+		        phy2: ethernet-phy@2 {
+		                reg = <2>;
+		        };
+		        phy3: ethernet-phy@3 {
+		                reg = <3>;
+		        };
+		        phy4: ethernet-phy@4 {
+		                reg = <4>;
+		        };
+		};
+
+		wifi0: wifi@a000000 {
+			compatible = "qcom,ipq4019-wifi";
+			reg = <0xa000000 0x200000>;
+			resets = <&gcc WIFI0_CPU_INIT_RESET>,
+				 <&gcc WIFI0_RADIO_SRIF_RESET>,
+				 <&gcc WIFI0_RADIO_WARM_RESET>,
+				 <&gcc WIFI0_RADIO_COLD_RESET>,
+				 <&gcc WIFI0_CORE_WARM_RESET>,
+				 <&gcc WIFI0_CORE_COLD_RESET>;
+			reset-names = "wifi_cpu_init", "wifi_radio_srif",
+				      "wifi_radio_warm", "wifi_radio_cold",
+				      "wifi_core_warm", "wifi_core_cold";
+			clocks = <&gcc GCC_WCSS2G_CLK>,
+				 <&gcc GCC_WCSS2G_REF_CLK>,
+				 <&gcc GCC_WCSS2G_RTC_CLK>;
+			clock-names = "wifi_wcss_cmd", "wifi_wcss_ref",
+				      "wifi_wcss_rtc";
+			interrupts = <GIC_SPI 32 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 33 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 34 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 35 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 36 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 37 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 38 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 39 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 40 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 41 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 42 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 43 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 44 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 45 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 46 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 47 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 168 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names =  "msi0",  "msi1",  "msi2",  "msi3",
+					   "msi4",  "msi5",  "msi6",  "msi7",
+					   "msi8",  "msi9", "msi10", "msi11",
+					  "msi12", "msi13", "msi14", "msi15",
+					  "legacy";
+			status = "disabled";
+		};
+
+		wifi1: wifi@a800000 {
+			compatible = "qcom,ipq4019-wifi";
+			reg = <0xa800000 0x200000>;
+			resets = <&gcc WIFI1_CPU_INIT_RESET>,
+				 <&gcc WIFI1_RADIO_SRIF_RESET>,
+				 <&gcc WIFI1_RADIO_WARM_RESET>,
+				 <&gcc WIFI1_RADIO_COLD_RESET>,
+				 <&gcc WIFI1_CORE_WARM_RESET>,
+				 <&gcc WIFI1_CORE_COLD_RESET>;
+			reset-names = "wifi_cpu_init", "wifi_radio_srif",
+				      "wifi_radio_warm", "wifi_radio_cold",
+				      "wifi_core_warm", "wifi_core_cold";
+			clocks = <&gcc GCC_WCSS5G_CLK>,
+				 <&gcc GCC_WCSS5G_REF_CLK>,
+				 <&gcc GCC_WCSS5G_RTC_CLK>;
+			clock-names = "wifi_wcss_cmd", "wifi_wcss_ref",
+				      "wifi_wcss_rtc";
+			interrupts = <GIC_SPI 48 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 49 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 50 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 51 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 52 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 53 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 54 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 55 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 56 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 57 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 58 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 59 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 60 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 61 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 62 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 63 IRQ_TYPE_EDGE_RISING>,
+				     <GIC_SPI 169 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names =  "msi0",  "msi1",  "msi2",  "msi3",
+					   "msi4",  "msi5",  "msi6",  "msi7",
+					   "msi8",  "msi9", "msi10", "msi11",
+					  "msi12", "msi13", "msi14", "msi15",
+					  "legacy";
+			status = "disabled";
+		};
+		
+		usb3_ss_phy: ssphy@9a000 {
+		        compatible = "qca,uni-ssphy";
+		        reg = <0x9a000 0x800>;
+		        reg-names = "phy_base";
+		        resets = <&gcc USB3_UNIPHY_PHY_ARES>;
+		        reset-names = "por_rst";
+		        qca,host = <1>;
+		        qca,emulation = <0>;
+		        status = "ok";
+		};
+
+		dummy_ss_phy: ssphy@1 {
+		        compatible = "qca,dummy-ssphy";
+		        status = "ok";
+		};
+
+		usb3_hs_phy: hsphy@a6000 {
+		        compatible = "qca,baldur-usb3-hsphy";
+		        reg = <0xa6000 0x40>;
+		        reg-names = "phy_base";
+		        resets = <&gcc USB3_HSPHY_POR_ARES>, <&gcc USB3_HSPHY_S_ARES>;
+		        reset-names = "por_rst", "srif_rst";
+		        qca,host = <1>;
+		        qca,emulation = <0>;
+		        status = "ok";
+		};
+
+		usb2_hs_phy: hsphy@a8000 {
+		        compatible = "qca,baldur-usb2-hsphy";
+		        reg = <0xa8000 0x40>;
+		        reg-names = "phy_base";
+		        resets = <&gcc USB2_HSPHY_POR_ARES>, <&gcc USB2_HSPHY_S_ARES>;
+		        reset-names = "por_rst", "srif_rst";
+		        qca,host = <1>;
+		        qca,emulation = <0>;
+		        status = "ok";
+		};
+
+		usb3: usb3@8a00000 {
+		        compatible = "qca,dwc3";
+		        #address-cells = <1>;
+		        #size-cells = <1>;
+		        ranges;
+		        reg = <0x8af8800 0x100>;
+		        reg-names = "qscratch_base";
+		        clocks = <&gcc GCC_USB3_MASTER_CLK>,
+		                <&gcc GCC_USB3_SLEEP_CLK>,
+		                <&gcc GCC_USB3_MOCK_UTMI_CLK>;
+		        clock-names = "master",
+		                "sleep",
+		                "mock_utmi";
+		        qca,host = <1>;
+		        status = "ok";
+		
+		        dwc3@8a00000 {
+		                compatible = "snps,dwc3";
+		                reg = <0x8a00000 0xf8000>;
+		                interrupts = <0 132 0>;
+		                usb-phy = <&usb3_hs_phy>, <&usb3_ss_phy>;
+		                phy-names = "usb2-phy", "usb3-phy";
+		                tx-fifo-resize;
+		                dr_mode = "host";
+		                usb2-susphy-quirk;
+		                usb2-host-discon-quirk;
+		                usb2-host-discon-phy-misc-reg = <0x24>;
+		                usb2-host-discon-mask = <0x100>;
+		        };
+		};
+		
+		usb2: usb2@6000000 {
+		        compatible = "qca,dwc3";
+		        #address-cells = <1>;
+		        #size-cells = <1>;
+		        ranges;
+		        reg = <0x60f8800 0x100>;
+		        reg-names = "qscratch_base";
+		        clocks = <&gcc GCC_USB2_MASTER_CLK>,
+		                <&gcc GCC_USB2_SLEEP_CLK>,
+		                <&gcc GCC_USB2_MOCK_UTMI_CLK>;
+		        clock-names = "master",
+		                "sleep",
+		                "mock_utmi";
+		        qca,host = <1>;
+		        status = "ok";
+		
+		        dwc3@6000000 {
+		                compatible = "snps,dwc3";
+		                reg = <0x6000000 0xf8000>;
+		                interrupts = <0 136 0>;
+		                usb-phy = <&usb2_hs_phy>, <&dummy_ss_phy>;
+		                phy-names = "usb2-phy", "usb3-phy";
+		                tx-fifo-resize;
+		                dr_mode = "host";
+		                usb2-susphy-quirk;
+		                usb2-host-discon-quirk;
+		                usb2-host-discon-phy-misc-reg = <0x24>;
+		                usb2-host-discon-mask = <0x100>;
+		        };
+		};				
+
+                spi_0: spi@78b5000 { /* BLSP1 QUP1 */
+                        pinctrl-0 = <&spi_0_pins>;
+                        pinctrl-names = "default";
+                        status = "ok";
+
+                        m25p80@0 {
+                                #address-cells = <1>;
+                                #size-cells = <1>;
+                                reg = <0>;
+                                compatible = "n25q128a11";
+                                linux,modalias = "m25p80", "n25q128a11";
+                                spi-max-frequency = <24000000>;
+                                use-default-sizes;
+                        };
+                };
+
+                i2c_0: i2c@78b7000 { /* BLSP1 QUP2 */
+                        pinctrl-0 = <&i2c_0_pins>;
+                        pinctrl-1 = <&i2c_0_pins>;
+                        pinctrl-names = "i2c_active", "i2c_sleep";
+                        status = "ok";
+
+                        qca_codec: qca_codec@12 {
+                                compatible = "qca,ipq40xx-codec";
+                                reg = <0x12>;
+                                status = "disabled";
+                        };
+
+                        lcd_ts: lcd_ts@40 {
+                                compatible = "qca,gsl1680_ts";
+                                reg = <0x40>;
+                                status = "disabled";
+                        };
+                };
+
+                pinctrl@1000000 {
+                        serial_0_pins: serial0_pinmux {
+                                mux {
+                                        pins = "gpio16", "gpio17";
+                                        function = "blsp_uart0";
+                                        bias-disable;
+                                };
+                        };
+
+                        serial_1_pins: serial1_pinmux {
+                                mux {
+                                        pins = "gpio8", "gpio9";
+                                        function = "blsp_uart1";
+                                        bias-disable;
+                                };
+                        };
+
+                        uart1_pins: uart1_pinmux {
+                                mux {
+                                        pins = "gpio8", "gpio9", "gpio10", "gpio11";
+                                        function = "blsp_uart1";
+                                        bias-disable;
+                                };
+                        };
+
+                        spi_0_pins: spi_0_pinmux {
+                                mux {
+                                        pins = "gpio12", "gpio13", "gpio14", "gpio15";
+                                        function = "blsp_spi0";
+                                        bias-disable;
+                                };
+                        };
+
+                        i2c_0_pins: i2c_0_pinmux {
+                                mux {
+                                        pins = "gpio20", "gpio21";
+                                        function = "blsp_i2c0";
+                                        bias-disable;
+                                };
+                        };
+
+
+                        nand_pins: nand-pins {
+                                pins = "gpio53", "gpio55", "gpio56",
+                                       "gpio57", "gpio58", "gpio59",
+                                       "gpio60", "gpio62", "gpio63",
+                                       "gpio64", "gpio65", "gpio66",
+                                       "gpio67", "gpio68", "gpio69";
+                                function = "qpic";
+                        };
+
+                        led_0_pins: led0_pinmux {
+                                mux_1 {
+                                        pins = "gpio36";
+                                        function = "led0";
+                                        bias-pull-down;
+                                };
+                                mux_2 {
+                                        pins = "gpio40";
+                                        function = "led4";
+                                        bias-pull-down;
+                                };
+                        };
+
+                        sd_0_pins: sd_0_pinmux {
+                                sd0 {
+                                        pins = "gpio23";
+                                        function = "sdio0";
+                                        drive-strength = <10>;
+                                };
+                                sd1 {
+                                        pins = "gpio24";
+                                        function = "sdio1";
+                                        drive-strength = <10>;
+                                };
+                                sd2 {
+                                        pins = "gpio25";
+                                        function = "sdio2";
+                                        drive-strength = <10>;
+                                };
+                                sd3 {
+                                        pins = "gpio26";
+                                        function = "sdio3";
+                                        drive-strength = <10>;
+                                };
+                                sdclk {
+                                        pins = "gpio27";
+                                        function = "sdio_clk";
+                                        drive-strength = <16>;
+                                };
+                                sdcmd {
+                                        pins = "gpio28";
+                                        function = "sdio_cmd";
+                                        drive-strength = <10>;
+                                };
+                                sd4 {
+                                        pins = "gpio29";
+                                        function = "sdio4";
+                                        drive-strength = <10>;
+                                };
+                                sd5 {
+                                        pins = "gpio30";
+                                        function = "sdio5";
+                                        drive-strength = <10>;
+                                };
+                                sd6 {
+                                        pins = "gpio31";
+                                        function = "sdio6";
+                                        drive-strength = <10>;
+                                };
+                                sd7 {
+                                        pins = "gpio32";
+                                        function = "sdio7";
+                                        drive-strength = <10>;
+                                        bias-disable;
+                                };
+                        };
+
+                        ts_0_pins: ts_0_pinmux {
+                                mux_1 {
+                                        pins = "gpio34";
+                                        output-high;
+                                };
+                                mux_2 {
+                                        pins= "gpio35";
+                                        input-enable;
+                                        bias-pull-up;
+                                };
+                        };
+                };
+
+		qcom: ledc@1937000  {
+		        compatible = "qca,ledc";
+		        reg = <0x1937000 0x20070>;
+		        reg-names = "ledc_base_addr";
+		        qcom,tcsr_ledc_values = <0x320193 0x14720800 0x20d 0x0 \
+		                0x0 0xFFFFFFFF 0x0 0x7 0x7D0010 0x0 0x10482090 0x3FFFDFC>;
+		        qcom,ledc_blink_indices_cnt = <0>;
+		        qcom,ledc_blink_indices = <0>;
+                        pinctrl-0 = <&led_0_pins>;
+                        pinctrl-names = "default";
+		        status = "ok";
+		};
+
+                vccq_sd0: regulator@0 {
+                        compatible = "qcom,regulator-ipq40xx";
+                        regulator-name = "SD0 VccQ";
+                        regulator-min-microvolt = <1800000>;
+                        regulator-max-microvolt = <3000000>;
+                        states = <3000000 0x3
+                                1800000 0x1>;
+                        reg = <0x01948000 0x4>;
+                        mask = <0x3>;
+                };
+
+		sdhci@7824000 {
+		        compatible = "qcom,sdhci-msm-v4";
+		        reg = <0x7824900 0x11c>, <0x7824000 0x800>;
+		        interrupts = <0 123 0>, <0 138 0>;
+		        bus-width = <8>;
+		        clocks = <&gcc GCC_SDCC1_APPS_CLK>, <&gcc GCC_SDCC1_AHB_CLK>;
+		        clock-names = "core", "iface";
+                        pinctrl-0 = <&sd_0_pins>;
+                        pinctrl-names = "default";
+                        vqmmc-supply = <&vccq_sd0>;
+                        cd-gpios = <&tlmm 22 0x1>;
+                        sd-ldo-gpios = <&tlmm 33 0x1>;
+		        status = "ok";
+		};
+
+                serial@78af000 {
+                        pinctrl-0 = <&serial_0_pins>;
+                        pinctrl-names = "default";
+                        status = "ok";
+                };
+
+                serial@78b0000 {
+                        pinctrl-0 = <&serial_1_pins>;
+                        pinctrl-names = "default";
+                        status = "ok";
+                };
+
+                dma@7884000 {
+                        status = "ok";
+                };
+
+                i2c@78b7000 { /* BLSP1 QUP2 */
+                        pinctrl-0 = <&i2c_0_pins>;
+                        pinctrl-names = "default";
+                        status = "ok";
+                };
+
+                dma@7984000 {
+                        status = "ok";
+                };
+
+                qpic-nand@79b0000 {
+                        pinctrl-0 = <&nand_pins>;
+                        pinctrl-names = "default";
+                        status = "ok";
+                };
+
+                qcom_crypto: qcrypto@8e20000 {
+                        status = "ok";
+                };
+
+                qcom_cedev: qcedev@8e20000 {
+                        status = "ok";
+                };
+
+                gpio_keys {
+                        compatible = "gpio-keys";
+
+                        button@1 {
+                                label = "wps";
+                                linux,code = <KEY_WPS_BUTTON>;
+                                gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+                                linux,input-type = <1>;
+                        };
+                };
+        };
+};

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -117,6 +117,23 @@ define Device/glinet_gl-b1300
 endef
 TARGET_DEVICES += glinet_gl-b1300
 
+define Device/linksys_ea8300
+        $(call Device/LegacyImage)
+        DEVICE_DTS := qcom-ipq4019-ea8300
+        PAGESIZE := 2048
+        BLOCKSIZE := 128k
+        KERNEL_SIZE := 3072k
+        KERNEL = kernel-bin | append-dtb | uImage none | append-uImage-fakehdr filesystem
+        BOARD_NAME := ea8300
+        SUPPORTED_DEVICES += ea8300
+        UBINIZE_OPTS := -E 5
+        IMAGES := factory.bin sysupgrade.bin
+        IMAGE/factory.bin := append-kernel | pad-to $$$${KERNEL_SIZE} | append-ubi
+        DEVICE_TITLE := Linksys EA8300
+        DEVICE_PACKAGES := ath10k-firmware-qca9888 uboot-envtools
+endef
+TARGET_DEVICES += linksys_ea8300
+
 define Device/meraki_mr33
 	$(call Device/FitImage)
 	DEVICE_DTS := qcom-ipq4029-mr33

--- a/target/linux/ipq40xx/patches-4.14/069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-4.14/069-arm-boot-add-dts-files.patch
@@ -1,0 +1,34 @@
+From 8f68331e14dff9a101f2d0e1d6bec84a031f27ee Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 9 Mar 2017 11:03:18 +0100
+Subject: [PATCH 69/69] arm: boot: add dts files
+
+Signed-off-by: John Crispin <john@phrozen.org>
+---
+ arch/arm/boot/dts/Makefile | 14 ++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -697,7 +697,21 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+ 	qcom-apq8074-dragonboard.dtb \
+ 	qcom-apq8084-ifc6540.dtb \
+ 	qcom-apq8084-mtp.dtb \
++	qcom-ipq4018-a42.dtb \
++	qcom-ipq4018-ex6100v2.dtb \
++	qcom-ipq4018-ex6150v2.dtb \
++	qcom-ipq4018-fritz4040.dtb \
++	qcom-ipq4018-jalapeno.dtb \
++	qcom-ipq4018-nbg6617.dtb \
++	qcom-ipq4018-rt-ac58u.dtb \
++	qcom-ipq4018-wre6606.dtb \
+ 	qcom-ipq4019-ap.dk01.1-c1.dtb \
++	qcom-ipq4019-a62.dtb \
++	qcom-ipq4019-ap.dk04.1-c1.dtb \
++	qcom-ipq4019-ea8300.dtb \
++	qcom-ipq4028-wpj428.dtb \
++	qcom-ipq4029-gl-b1300.dtb \
++	qcom-ipq4029-mr33.dtb \
+ 	qcom-ipq8064-ap148.dtb \
+ 	qcom-msm8660-surf.dtb \
+ 	qcom-msm8960-cdp.dtb \

--- a/target/linux/ipq40xx/patches-4.14/855-ipq40xx-add-ess-resets.patch
+++ b/target/linux/ipq40xx/patches-4.14/855-ipq40xx-add-ess-resets.patch
@@ -1,0 +1,39 @@
+--- a/drivers/clk/qcom/gcc-ipq4019.c	2018-07-17 01:57:48.504648996 +0200
++++ b/drivers/clk/qcom/gcc-ipq4019.c	2018-07-17 01:59:59.553495019 +0200
+@@ -1746,6 +1746,17 @@
+ 	[GCC_TCSR_BCR] = {0x22000, 0},
+ 	[GCC_MPM_BCR] = {0x24000, 0},
+ 	[GCC_SPDM_BCR] = {0x25000, 0},
++	[ESS_MAC1_ARES] = {0x1200C, 0},
++	[ESS_MAC2_ARES] = {0x1200C, 1},
++	[ESS_MAC3_ARES] = {0x1200C, 2},
++	[ESS_MAC4_ARES] = {0x1200C, 3},
++	[ESS_MAC5_ARES] = {0x1200C, 4},
++	[ESS_PSGMII_ARES] = {0x1200C, 5},
++	[ESS_MAC1_CLK_DIS] = {0x1200C, 8},
++	[ESS_MAC2_CLK_DIS] = {0x1200C, 9},
++	[ESS_MAC3_CLK_DIS] = {0x1200C, 10},
++	[ESS_MAC4_CLK_DIS] = {0x1200C, 11},
++	[ESS_MAC5_CLK_DIS] = {0x1200C, 12},
+ };
+ 
+ static const struct regmap_config gcc_ipq4019_regmap_config = {
+--- a/include/dt-bindings/clock/qcom,gcc-ipq4019.h	2018-07-17 02:07:20.261842967 +0200
++++ b/include/dt-bindings/clock/qcom,gcc-ipq4019.h	2018-07-17 02:07:55.659160182 +0200
+@@ -165,5 +165,16 @@
+ #define GCC_QDSS_BCR					69
+ #define GCC_MPM_BCR					70
+ #define GCC_SPDM_BCR					71
++#define ESS_MAC1_ARES					72
++#define ESS_MAC2_ARES					73
++#define ESS_MAC3_ARES					74
++#define ESS_MAC4_ARES					75
++#define ESS_MAC5_ARES					76
++#define ESS_PSGMII_ARES					77
++#define ESS_MAC1_CLK_DIS				78
++#define ESS_MAC2_CLK_DIS				79
++#define ESS_MAC3_CLK_DIS				80
++#define ESS_MAC4_CLK_DIS				81
++#define ESS_MAC5_CLK_DIS				82
+ 
+ #endif

--- a/target/linux/ipq40xx/patches-4.14/856-ipq40xx-fix-mdio-driver-to-detect-ipq4019.patch
+++ b/target/linux/ipq40xx/patches-4.14/856-ipq40xx-fix-mdio-driver-to-detect-ipq4019.patch
@@ -1,0 +1,84 @@
+--- a/drivers/net/phy/mdio-ipq40xx.c	2018-07-17 02:13:40.347995141 +0200
++++ b/drivers/net/phy/mdio-ipq40xx.c	2018-07-17 02:16:57.231355837 +0200
+@@ -22,6 +22,7 @@
+ #include <linux/of_mdio.h>
+ #include <linux/phy.h>
+ #include <linux/platform_device.h>
++#include <linux/of_gpio.h>
+ 
+ #define MDIO_CTRL_0_REG		0x40
+ #define MDIO_CTRL_1_REG		0x44
+@@ -122,11 +123,61 @@
+ 	return 0;
+ }
+ 
++static int ipq40xx_phy_reset(struct platform_device *pdev)
++{
++	struct device_node *mdio_node;
++	int phy_reset_gpio_number;
++	int ret;
++
++	mdio_node = of_find_node_by_name(NULL, "mdio");
++	if (!mdio_node) {
++		dev_err(&pdev->dev, "Could not find mdio node\n");
++		return -ENOENT;
++	}
++
++	ret = of_get_named_gpio(mdio_node, "phy-reset-gpio", 0);
++	if (ret < 0) {
++		dev_warn(&pdev->dev, "Could not find DT gpio phy-reset-gpio missing/malformed:%d\n",ret);
++		ret = 0;
++		return ret;
++	}
++
++	phy_reset_gpio_number = ret;
++
++	ret = gpio_request(phy_reset_gpio_number, "phy-reset-gpio");
++	if (ret) {
++		dev_err(&pdev->dev, "Can't get phy-reset-gpio %d\n", ret);
++		return ret;
++	}
++
++	ret = gpio_direction_output(phy_reset_gpio_number, 0x0);
++	if (ret) {
++		dev_err(&pdev->dev,
++			"Can't set direction for phy-reset-gpio %d\n", ret);
++		goto phy_reset_out;
++	}
++
++	usleep_range(1000, 10005);
++
++	gpio_set_value(phy_reset_gpio_number, 0x01);
++
++phy_reset_out:
++	gpio_free(phy_reset_gpio_number);
++
++	return ret;
++}
++
+ static int ipq40xx_mdio_probe(struct platform_device *pdev)
+ {
+ 	struct ipq40xx_mdio_data *am;
+ 	struct resource *res;
+-	int i;
++	int i, ret;
++
++	ret = ipq40xx_phy_reset(pdev);
++	if (ret) {
++		dev_err(&pdev->dev, "Could not find qca8075 reset gpio\n");
++		return ret;
++	}
+ 
+ 	am = devm_kzalloc(&pdev->dev, sizeof(*am), GFP_KERNEL);
+ 	if (!am)
+@@ -151,8 +202,8 @@
+ 	writel(CTRL_0_REG_DEFAULT_VALUE, am->membase + MDIO_CTRL_0_REG);
+ 
+ 	am->mii_bus->name = "ipq40xx_mdio";
+-	am->mii_bus->read = ipq40xx_mdio_read;
+-	am->mii_bus->write = ipq40xx_mdio_write;
++	am->mii_bus->read = &ipq40xx_mdio_read;
++	am->mii_bus->write = &ipq40xx_mdio_write;
+ 	memcpy(am->mii_bus->irq, am->phy_irq, sizeof(am->phy_irq));
+ 	am->mii_bus->priv = am;
+ 	am->mii_bus->parent = &pdev->dev;


### PR DESCRIPTION
Changes to be committed:
	modified:   package/boot/uboot-envtools/files/ipq40xx
	modified:   target/linux/ipq40xx/Makefile
	modified:   target/linux/ipq40xx/base-files/etc/board.d/02_network
	modified:   target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
	new file:   target/linux/ipq40xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
	new file:   target/linux/ipq40xx/base-files/etc/init.d/linksys_recovery
	new file:   target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
	modified:   target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
	new file:   target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dts
	new file:   target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-ea8300.dtsi
	modified:   target/linux/ipq40xx/image/Makefile
	new file:   target/linux/ipq40xx/patches-4.14/069-arm-boot-add-dts-files.patch
	new file:   target/linux/ipq40xx/patches-4.14/855-ipq40xx-add-ess-resets.patch
	new file:   target/linux/ipq40xx/patches-4.14/856-ipq40xx-fix-mdio-driver-to-detect-ipq4019.patch

Image has been built successfully, but not yet tested on hardware.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
