### PR TITLE
Fixed qcom-ipq4019-ea8300.dtsi missing include.

### DIFF
--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-bus.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-bus.dtsi
@@ -1,0 +1,1142 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <dt-bindings/msm/msm-bus-ids.h>
+
+/ {
+
+soc {
+	ad_hoc_bus: ad-hoc-bus@580000 {
+		compatible = "qcom,msm-bus-device";
+		reg = <0x580000 0x14000>,
+			<0x500000 0x11000>;
+		reg-names = "snoc-base", "pcnoc-base";
+
+		/*Buses*/
+
+		fab_pcnoc: fab-pcnoc {
+			cell-id = <MSM_BUS_FAB_PERIPH_NOC>;
+			label = "fab-pcnoc";
+			qcom,fab-dev;
+			qcom,base-name = "pcnoc-base";
+			qcom,bypass-qos-prg;
+			qcom,bus-type = <1>;
+			qcom,qos-off = <0x1000>;
+			qcom,base-offset = <0x0>;
+			clocks = <>;
+		};
+
+		fab_snoc: fab-snoc {
+			cell-id = <MSM_BUS_FAB_SYS_NOC>;
+			label = "fab-snoc";
+			qcom,fab-dev;
+			qcom,base-name = "snoc-base";
+			qcom,bypass-qos-prg;
+			qcom,bus-type = <1>;
+			qcom,qos-off = <0x80>;
+			qcom,base-offset = <0x0>;
+			clocks = <>;
+		};
+
+		/*Masters*/
+
+		mas_blsp_bam: mas-blsp-bam {
+			cell-id = <MSM_BUS_MASTER_BLSP_BAM>;
+			label = "mas-blsp-bam";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_BLSP_BAM>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_usb2_bam: mas-usb2-bam {
+			cell-id = <MSM_BUS_MASTER_USB2_BAM>;
+			label = "mas-usb2-bam";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <15>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_USB2_BAM>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_adss_dma0: mas-adss-dma0 {
+			cell-id = <MSM_BUS_MASTER_ADDS_DMA0>;
+			label = "mas-adss-dma0";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_ADSS_DMA0>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_adss_dma1: mas-adss-dma1 {
+			cell-id = <MSM_BUS_MASTER_ADDS_DMA1>;
+			label = "mas-adss-dma1";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_ADSS_DMA1>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_adss_dma2: mas-adss-dma2 {
+			cell-id = <MSM_BUS_MASTER_ADDS_DMA2>;
+			label = "mas-adss-dma2";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_ADSS_DMA2>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_adss_dma3: mas-adss-dma3 {
+			cell-id = <MSM_BUS_MASTER_ADDS_DMA3>;
+			label = "mas-adss-dma3";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_ADSS_DMA3>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_qpic_bam: mas-qpic-bam {
+			cell-id = <MSM_BUS_MASTER_QPIC_BAM>;
+			label = "mas-qpic-bam";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QPIC_BAM>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_spdm: mas-spdm {
+			cell-id = <MSM_BUS_MASTER_SPDM>;
+			label = "mas-spdm";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SPDM>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_pcnoc_cfg: mas-pcnoc-cfg {
+			cell-id = <MSM_BUS_MASTER_PNOC_CFG>;
+			label = "mas-pcnoc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_srvc_pcnoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_CFG>;
+		};
+
+		mas_tic: mas-tic {
+			cell-id = <MSM_BUS_MASTER_TIC>;
+			label = "mas-tic";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_int_0 &slv_pcnoc_snoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_TIC>;
+		};
+
+		mas_sdcc_bam: mas-sdcc-bam {
+			cell-id = <MSM_BUS_MASTER_SDCC_BAM>;
+			label = "mas-sdcc-bam";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <14>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SDCC_BAM>;
+			qcom,blacklist = <&slv_tcsr &slv_mdio &slv_adss_cfg
+				 &slv_fephy_cfg &slv_wss1_apu_cfg &slv_ddrc_mpu1_cfg
+				 &slv_ddrc_mpu0_cfg &slv_qpic_cfg &slv_ddrc_cfg
+				 &slv_pcnoc_cfg &slv_ess_apu_cfg &slv_imem_cfg
+				 &slv_srif &slv_prng &slv_qdss_cfg
+				 &slv_wss0_apu_cfg &slv_ddrc_apu_cfg &slv_gcnt
+				 &slv_tlmm &slv_wss0_vmidmt_cfg &slv_prng_apu_cfg
+				 &slv_boot_rom &slv_security &slv_spdm
+				 &slv_pcnoc_mpu_cfg &slv_ddrc_mpu2_cfg &slv_ess_vmidmt_cfg
+				 &slv_qhss_apu_cfg &slv_adss_vmidmt_cfg &slv_clk_ctl
+				 &slv_adss_apu &slv_blsp_cfg &slv_usb2_cfg
+				 &slv_srvc_pcnoc &slv_snoc_mpu_cfg &slv_wss1_vmidmt_cfg
+				 &slv_sdcc_cfg &slv_snoc_cfg>;
+		};
+
+		mas_snoc_pcnoc: mas-snoc-pcnoc {
+			cell-id = <MSM_BUS_SNOC_PNOC_MAS>;
+			label = "mas-snoc-pcnoc";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <16>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_0>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_PCNOC>;
+		};
+
+		mas_qdss_dap: mas-qdss-dap {
+			cell-id = <MSM_BUS_MASTER_QDSS_DAP>;
+			label = "mas-qdss-dap";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&pcnoc_int_0 &slv_pcnoc_snoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_DAP>;
+		};
+
+		mas_ddrc_snoc: mas-ddrc-snoc {
+			cell-id = <MSM_BUS_MASTER_DDRC_SNOC>;
+			label = "mas-ddrc-snoc";
+			qcom,buswidth = <16>;
+			qcom,ap-owned;
+			qcom,connections = <&snoc_int_0 &snoc_int_1
+				 &slv_pcie>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_DDRC_SNOC>;
+			qcom,blacklist = <&slv_snoc_ddrc_m1 &slv_srvc_snoc>;
+		};
+
+		mas_wss_0: mas-wss-0 {
+			cell-id = <MSM_BUS_MASTER_WSS_0>;
+			label = "mas-wss-0";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <26>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_WSS_0>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_pcie
+				 &slv_wss1_cfg &slv_wss0_cfg &slv_crypto_cfg
+				 &slv_srvc_snoc>;
+		};
+
+		mas_wss_1: mas-wss-1 {
+			cell-id = <MSM_BUS_MASTER_WSS_1>;
+			label = "mas-wss-1";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <27>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_WSS_1>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_pcie
+				 &slv_wss1_cfg &slv_wss0_cfg &slv_crypto_cfg
+				 &slv_srvc_snoc>;
+		};
+
+		mas_crypto: mas-crypto {
+			cell-id = <MSM_BUS_MASTER_CRYPTO>;
+			label = "mas-crypto";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <5>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &snoc_int_1
+				 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_CRYPTO>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_a7ss
+				 &slv_pcie &slv_qdss_stm &slv_crypto_cfg
+				 &slv_srvc_snoc>;
+		};
+
+		mas_ess: mas-ess {
+			cell-id = <MSM_BUS_MASTER_ESS>;
+			label = "mas-ess";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <44>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_ESS>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_a7ss
+				 &slv_pcie &slv_qdss_stm &slv_wss1_cfg
+				 &slv_wss0_cfg &slv_crypto_cfg &slv_srvc_snoc>;
+		};
+
+		mas_pcie: mas-pcie {
+			cell-id = <MSM_BUS_MASTER_PCIE>;
+			label = "mas-pcie";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <6>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCIE>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_pcie
+				 &slv_qdss_stm &slv_wss1_cfg &slv_wss0_cfg
+				 &slv_crypto_cfg &slv_srvc_snoc>;
+		};
+
+		mas_usb3: mas-usb3 {
+			cell-id = <MSM_BUS_MASTER_USB3>;
+			label = "mas-usb3";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <7>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_USB3>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_a7ss
+				 &slv_pcie &slv_qdss_stm &slv_wss1_cfg
+				 &slv_wss0_cfg &slv_crypto_cfg &slv_srvc_snoc>;
+		};
+
+		mas_qdss_etr: mas-qdss-etr {
+			cell-id = <MSM_BUS_MASTER_QDSS_ETR>;
+			label = "mas-qdss-etr";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,qport = <544>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&qdss_int>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_ETR>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_a7ss
+				 &slv_pcie &slv_qdss_stm &slv_wss1_cfg
+				 &slv_wss0_cfg &slv_crypto_cfg &slv_srvc_snoc>;
+		};
+
+		mas_qdss_bamndp: mas-qdss-bamndp {
+			cell-id = <MSM_BUS_MASTER_QDSS_BAMNDP>;
+			label = "mas-qdss-bamndp";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <576>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&qdss_int>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_BAMNDP>;
+			qcom,blacklist = <&slv_usb3_cfg &slv_ess_cfg &slv_a7ss
+				 &slv_pcie &slv_qdss_stm &slv_wss1_cfg
+				 &slv_wss0_cfg &slv_crypto_cfg &slv_srvc_snoc>;
+		};
+
+		mas_pcnoc_snoc: mas-pcnoc-snoc {
+			cell-id = <MSM_BUS_PNOC_SNOC_MAS>;
+			label = "mas-pcnoc-snoc";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <384>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_0 &snoc_int_1
+				 &slv_snoc_ddrc_m1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PNOC_SNOC>;
+			qcom,blacklist = <&slv_srvc_snoc>;
+		};
+
+		mas_snoc_cfg: mas-snoc-cfg {
+			cell-id = <MSM_BUS_MASTER_QDSS_SNOC_CFG>;
+			label = "mas-snoc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_srvc_snoc>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_SNOC_CFG>;
+		};
+
+		/*Internal nodes*/
+
+
+		pcnoc_m_0: pcnoc-m-0 {
+			cell-id = <MSM_BUS_PNOC_M_0>;
+			label = "pcnoc-m-0";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <12>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_M_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_M_0>;
+		};
+
+		pcnoc_m_1: pcnoc-m-1 {
+			cell-id = <MSM_BUS_PNOC_M_1>;
+			label = "pcnoc-m-1";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,qport = <13>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_M_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_M_1>;
+		};
+
+		pcnoc_int_0: pcnoc-int-0 {
+			cell-id = <MSM_BUS_PNOC_INT_0>;
+			label = "pcnoc-int-0";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,connections = < &pcnoc_s_1 &pcnoc_s_2 &pcnoc_s_0
+				 &pcnoc_s_4 &pcnoc_s_5
+				 &pcnoc_s_6 &pcnoc_s_7
+				 &pcnoc_s_8 &pcnoc_s_9
+				 &pcnoc_s_3>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_INT_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_INT_0>;
+		};
+
+		pcnoc_s_0: pcnoc-s-0 {
+			cell-id = <MSM_BUS_PNOC_SLV_0>;
+			label = "pcnoc-s-0";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_clk_ctl &slv_tcsr &slv_security
+				 &slv_tlmm>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_0>;
+		};
+
+		pcnoc_s_1: pcnoc-s-1 {
+			cell-id = <MSM_BUS_PNOC_SLV_1>;
+			label = "pcnoc-s-1";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_prng_apu_cfg &slv_prng&slv_imem_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_1>;
+		};
+
+		pcnoc_s_2: pcnoc-s-2 {
+			cell-id = <MSM_BUS_PNOC_SLV_2>;
+			label = "pcnoc-s-2";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_spdm &slv_pcnoc_mpu_cfg &slv_pcnoc_cfg
+				&slv_boot_rom>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_2>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_2>;
+		};
+
+		pcnoc_s_3: pcnoc-s-3 {
+			cell-id = <MSM_BUS_PNOC_SLV_3>;
+			label = "pcnoc-s-3";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_qdss_cfg&slv_gcnt &slv_snoc_cfg
+				 &slv_snoc_mpu_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_3>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_3>;
+		};
+
+		pcnoc_s_4: pcnoc-s-4 {
+			cell-id = <MSM_BUS_PNOC_SLV_4>;
+			label = "pcnoc-s-4";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_adss_cfg &slv_adss_vmidmt_cfg &slv_adss_apu>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_4>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_4>;
+		};
+
+		pcnoc_s_5: pcnoc-s-5 {
+			cell-id = <MSM_BUS_PNOC_SLV_5>;
+			label = "pcnoc-s-5";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_qhss_apu_cfg &slv_fephy_cfg &slv_mdio
+				 &slv_srif>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_5>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_5>;
+		};
+
+		pcnoc_s_6: pcnoc-s-6 {
+			cell-id = <MSM_BUS_PNOC_SLV_6>;
+			label = "pcnoc-s-6";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_ddrc_mpu0_cfg &slv_ddrc_apu_cfg &slv_ddrc_mpu2_cfg
+				&slv_ddrc_cfg &slv_ddrc_mpu1_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_6>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_6>;
+		};
+
+		pcnoc_s_7: pcnoc-s-7 {
+			cell-id = <MSM_BUS_PNOC_SLV_7>;
+			label = "pcnoc-s-7";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_ess_apu_cfg &slv_usb2_cfg&slv_ess_vmidmt_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_7>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_7>;
+		};
+
+		pcnoc_s_8: pcnoc-s-8 {
+			cell-id = <MSM_BUS_PNOC_SLV_8>;
+			label = "pcnoc-s-8";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_sdcc_cfg &slv_qpic_cfg&slv_blsp_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_8>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_8>;
+		};
+
+		pcnoc_s_9: pcnoc-s-9 {
+			cell-id = <MSM_BUS_PNOC_SLV_9>;
+			label = "pcnoc-s-9";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_wss1_apu_cfg &slv_wss1_vmidmt_cfg&slv_wss0_vmidmt_cfg
+				 &slv_wss0_apu_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_9>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_9>;
+		};
+
+		snoc_int_0: snoc-int-0 {
+			cell-id = <MSM_BUS_SNOC_INT_0>;
+			label = "snoc-int-0";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_ocimem&slv_qdss_stm>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_INT_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_INT_0>;
+		};
+
+		snoc_int_1: snoc-int-1 {
+			cell-id = <MSM_BUS_SNOC_INT_1>;
+			label = "snoc-int-1";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,connections = < &slv_crypto_cfg &slv_a7ss &slv_ess_cfg
+				 &slv_usb3_cfg &slv_wss1_cfg
+				&slv_wss0_cfg>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_INT_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_INT_1>;
+		};
+
+		qdss_int: qdss-int {
+			cell-id = <MSM_BUS_SNOC_QDSS_INT>;
+			label = "qdss-int";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,connections = <&snoc_int_0 &slv_snoc_ddrc_m1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_INT>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QDSS_INT>;
+		};
+		/*Slaves*/
+
+		slv_clk_ctl:slv-clk-ctl {
+			cell-id = <MSM_BUS_SLAVE_CLK_CTL>;
+			label = "slv-clk-ctl";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CLK_CTL>;
+		};
+
+		slv_security:slv-security {
+			cell-id = <MSM_BUS_SLAVE_SECURITY>;
+			label = "slv-security";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SECURITY>;
+		};
+
+		slv_tcsr:slv-tcsr {
+			cell-id = <MSM_BUS_SLAVE_TCSR>;
+			label = "slv-tcsr";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_TCSR>;
+		};
+
+		slv_tlmm:slv-tlmm {
+			cell-id = <MSM_BUS_SLAVE_TLMM>;
+			label = "slv-tlmm";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_TLMM>;
+		};
+
+		slv_imem_cfg:slv-imem-cfg {
+			cell-id = <MSM_BUS_SLAVE_IMEM_CFG>;
+			label = "slv-imem-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_IMEM_CFG>;
+		};
+
+		slv_prng:slv-prng {
+			cell-id = <MSM_BUS_SLAVE_PRNG>;
+			label = "slv-prng";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PRNG>;
+		};
+
+		slv_prng_apu_cfg:slv-prng-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_PRNG_APU_CFG>;
+			label = "slv-prng-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PRNG_APU_CFG>;
+		};
+
+		slv_boot_rom:slv-boot-rom {
+			cell-id = <MSM_BUS_SLAVE_BOOT_ROM>;
+			label = "slv-boot-rom";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_BOOT_ROM>;
+		};
+
+		slv_spdm:slv-spdm {
+			cell-id = <MSM_BUS_SLAVE_SPDM_WRAPPER>;
+			label = "slv-spdm";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SPDM_WRAPPER>;
+		};
+
+		slv_pcnoc_cfg:slv-pcnoc-cfg {
+			cell-id = <MSM_BUS_SLAVE_PNOC_CFG>;
+			label = "slv-pcnoc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PNOC_CFG>;
+		};
+
+		slv_pcnoc_mpu_cfg:slv-pcnoc-mpu-cfg {
+			cell-id = <MSM_BUS_SLAVE_PERIPH_MPU_CFG>;
+			label = "slv-pcnoc-mpu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PERIPH_MPU_CFG>;
+		};
+
+		slv_gcnt:slv-gcnt {
+			cell-id = <MSM_BUS_SLAVE_GCNT>;
+			label = "slv-gcnt";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_GCNT>;
+		};
+
+		slv_qdss_cfg:slv-qdss-cfg {
+			cell-id = <MSM_BUS_SLAVE_QDSS_CFG>;
+			label = "slv-qdss-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QDSS_CFG>;
+		};
+
+		slv_snoc_cfg:slv-snoc-cfg {
+			cell-id = <MSM_BUS_SLAVE_SNOC_CFG>;
+			label = "slv-snoc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_CFG>;
+		};
+
+		slv_snoc_mpu_cfg:slv-snoc-mpu-cfg {
+			cell-id = <MSM_BUS_SLAVE_SNOC_MPU_CFG>;
+			label = "slv-snoc-mpu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_MPU_CFG>;
+		};
+
+		slv_adss_cfg:slv-adss-cfg {
+			cell-id = <MSM_BUS_SLAVE_ADSS_CFG>;
+			label = "slv-adss-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ADSS_CFG>;
+		};
+
+		slv_adss_apu:slv-adss-apu {
+			cell-id = <MSM_BUS_SLAVE_ADSS_VMIDMT_CFG>;
+			label = "slv-adss-apu";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ADSS_APU>;
+		};
+
+		slv_adss_vmidmt_cfg:slv-adss-vmidmt-cfg {
+			cell-id = <MSM_BUS_SLAVE_ADSS_VMIDMT_CFG>;
+			label = "slv-adss-vmidmt-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ADSS_VMIDMT_CFG>;
+		};
+
+		slv_qhss_apu_cfg:slv-qhss-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_QHSS_APU_CFG>;
+			label = "slv-qhss-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QHSS_APU_CFG>;
+		};
+
+		slv_mdio:slv-mdio {
+			cell-id = <MSM_BUS_SLAVE_MDIO>;
+			label = "slv-mdio";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_MDIO>;
+		};
+
+		slv_fephy_cfg:slv-fephy-cfg {
+			cell-id = <MSM_BUS_SLAVE_FEPHY_CFG>;
+			label = "slv-fephy-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_FEPHY_CFG>;
+		};
+
+		slv_srif:slv-srif {
+			cell-id = <MSM_BUS_SLAVE_SRIF>;
+			label = "slv-srif";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SRIF>;
+		};
+
+		slv_ddrc_cfg:slv-ddrc-cfg {
+			cell-id = <MSM_BUS_SLAVE_DDRC_CFG>;
+			label = "slv-ddrc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DDRC_CFG>;
+		};
+
+		slv_ddrc_apu_cfg:slv-ddrc-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_DDRC_APU_CFG>;
+			label = "slv-ddrc-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DDRC_APU_CFG>;
+		};
+
+		slv_ddrc_mpu0_cfg:slv-ddrc-mpu0-cfg {
+			cell-id = <MSM_BUS_SLAVE_MPU0_CFG>;
+			label = "slv-ddrc-mpu0-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DDRC_MPU0_CFG>;
+		};
+
+		slv_ddrc_mpu1_cfg:slv-ddrc-mpu1-cfg {
+			cell-id = <MSM_BUS_SLAVE_MPU1_CFG>;
+			label = "slv-ddrc-mpu1-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DDRC_MPU1_CFG>;
+		};
+
+		slv_ddrc_mpu2_cfg:slv-ddrc-mpu2-cfg {
+			cell-id = <MSM_BUS_SLAVE_MPU2_CFG>;
+			label = "slv-ddrc-mpu2-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DDRC_MPU2_CFG>;
+		};
+
+		slv_ess_vmidmt_cfg:slv-ess-vmidmt-cfg {
+			cell-id = <MSM_BUS_SLAVE_ESS_VMIDMT_CFG>;
+			label = "slv-ess-vmidmt-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ESS_VMIDMT_CFG>;
+		};
+
+		slv_ess_apu_cfg:slv-ess-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_ESS_APU_CFG>;
+			label = "slv-ess-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ESS_APU_CFG>;
+		};
+
+		slv_usb2_cfg:slv-usb2-cfg {
+			cell-id = <MSM_BUS_SLAVE_USB2_CFG>;
+			label = "slv-usb2-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_USB2_CFG>;
+		};
+
+		slv_blsp_cfg:slv-blsp-cfg {
+			cell-id = <MSM_BUS_SLAVE_BLSP_CFG>;
+			label = "slv-blsp-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_BLSP_CFG>;
+		};
+
+		slv_qpic_cfg:slv-qpic-cfg {
+			cell-id = <MSM_BUS_SLAVE_QPIC_CFG>;
+			label = "slv-qpic-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QPIC_CFG>;
+		};
+
+		slv_sdcc_cfg:slv-sdcc-cfg {
+			cell-id = <MSM_BUS_SLAVE_SDCC_CFG>;
+			label = "slv-sdcc-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SDCC_CFG>;
+		};
+
+		slv_wss0_vmidmt_cfg:slv-wss0-vmidmt-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS0_VMIDMT_CFG>;
+			label = "slv-wss0-vmidmt-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS0_VMIDMT_CFG>;
+		};
+
+		slv_wss0_apu_cfg:slv-wss0-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS0_APU_CFG>;
+			label = "slv-wss0-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS0_APU_CFG>;
+		};
+
+		slv_wss1_vmidmt_cfg:slv-wss1-vmidmt-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS1_VMIDMT_CFG>;
+			label = "slv-wss1-vmidmt-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS1_VMIDMT_CFG>;
+		};
+
+		slv_wss1_apu_cfg:slv-wss1-apu-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS1_APU_CFG>;
+			label = "slv-wss1-apu-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS1_APU_CFG>;
+		};
+
+		slv_pcnoc_snoc:slv-pcnoc-snoc {
+			cell-id = <MSM_BUS_PNOC_SNOC_SLV>;
+			label = "slv-pcnoc-snoc";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_SNOC>;
+		};
+
+		slv_srvc_pcnoc:slv-srvc-pcnoc {
+			cell-id = <MSM_BUS_SLAVE_SRVC_PCNOC>;
+			label = "slv-srvc-pcnoc";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SRVC_PCNOC>;
+		};
+
+		slv_snoc_ddrc_m1:slv-snoc-ddrc-m1 {
+			cell-id = <MSM_BUS_SLAVE_SNOC_DDRC>;
+			label = "slv-snoc-ddrc-m1";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_DDRC>;
+		};
+
+		slv_a7ss:slv-a7ss {
+			cell-id = <MSM_BUS_SLAVE_A7SS>;
+			label = "slv-a7ss";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_A7SS>;
+		};
+
+		slv_ocimem:slv-ocimem {
+			cell-id = <MSM_BUS_SLAVE_OCIMEM>;
+			label = "slv-ocimem";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_OCIMEM>;
+		};
+
+		slv_wss0_cfg:slv-wss0-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS0_CFG>;
+			label = "slv-wss0-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS0_CFG>;
+		};
+
+		slv_wss1_cfg:slv-wss1-cfg {
+			cell-id = <MSM_BUS_SLAVE_WSS1_CFG>;
+			label = "slv-wss1-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_WSS1_CFG>;
+		};
+
+		slv_pcie:slv-pcie {
+			cell-id = <MSM_BUS_SLAVE_PCIE>;
+			label = "slv-pcie";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCIE>;
+		};
+
+		slv_usb3_cfg:slv-usb3-cfg {
+			cell-id = <MSM_BUS_SLAVE_USB3_CFG>;
+			label = "slv-usb3-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_USB3_CFG>;
+		};
+
+		slv_crypto_cfg:slv-crypto-cfg {
+			cell-id = <MSM_BUS_SLAVE_CRYPTO_CFG>;
+			label = "slv-crypto-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CRYPTO_CFG>;
+		};
+
+		slv_ess_cfg:slv-ess-cfg {
+			cell-id = <MSM_BUS_SLAVE_ESS_CFG>;
+			label = "slv-ess-cfg";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_ESS_CFG>;
+		};
+
+		slv_qdss_stm:slv-qdss-stm {
+			cell-id = <MSM_BUS_SLAVE_QDSS_STM>;
+			label = "slv-qdss-stm";
+			qcom,buswidth = <4>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QDSS_STM>;
+		};
+
+		slv_srvc_snoc:slv-srvc-snoc {
+			cell-id = <MSM_BUS_SLAVE_SRVC_SNOC>;
+			label = "slv-srvc-snoc";
+			qcom,buswidth = <8>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SRVC_SNOC>;
+		};
+	};
+};
+
+};


### PR DESCRIPTION
Added file target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-bus.dtsi
