### PR TITLE
modified:   target/linux/ipq40xx/image/Makefile

### DIFF
--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -122,13 +122,13 @@ define Device/linksys_ea8300
         DEVICE_DTS := qcom-ipq4019-ea8300
         PAGESIZE := 2048
         BLOCKSIZE := 128k
-        KERNEL_SIZE := 3072k
+        KERNEL_SIZE := 10240k
         KERNEL = kernel-bin | append-dtb | uImage none | append-uImage-fakehdr filesystem
         BOARD_NAME := ea8300
         SUPPORTED_DEVICES += ea8300
         UBINIZE_OPTS := -E 5
         IMAGES := factory.bin sysupgrade.bin
-        IMAGE/factory.bin := append-kernel | pad-to $$$${KERNEL_SIZE} | append-ubi
+        IMAGE/factory.bin := append-kernel | pad-to $$$${KERNEL_SIZE} | append-ubi | pad-to $$$$(PAGESIZE)
         DEVICE_TITLE := Linksys EA8300
         DEVICE_PACKAGES := ath10k-firmware-qca9888 uboot-envtools
 endef


### PR DESCRIPTION
Removed KERNEL_SIZE from EA8300 for testing purposes.

Image builder told us, that kernel is to big (about 8.15 MB)
